### PR TITLE
Refactor CID handling logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ SET(UNITTEST_SOURCE_FILES
     t/sentmap.c
     t/simple.c
     t/stream-concurrency.c
+    t/cid.c
     t/test.c)
 
 IF (WITH_DTRACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,8 @@ SET(QUICLY_LIBRARY_FILES
     lib/recvstate.c
     lib/sendstate.c
     lib/sentmap.c
-    lib/streambuf.c)
+    lib/streambuf.c
+    lib/cid.c)
 
 SET(UNITTEST_SOURCE_FILES
     deps/picotest/picotest.c

--- a/include/quicly.h
+++ b/include/quicly.h
@@ -41,6 +41,7 @@ extern "C" {
 #include "quicly/recvstate.h"
 #include "quicly/sendstate.h"
 #include "quicly/maxsender.h"
+#include "quicly/cid.h"
 
 #ifndef QUICLY_DEBUG
 #define QUICLY_DEBUG 0
@@ -83,7 +84,6 @@ typedef struct st_quicly_datagram_t {
     quicly_address_t dest, src;
 } quicly_datagram_t;
 
-typedef struct st_quicly_cid_t quicly_cid_t;
 typedef struct st_quicly_cid_plaintext_t quicly_cid_plaintext_t;
 typedef struct st_quicly_context_t quicly_context_t;
 typedef struct st_quicly_stream_t quicly_stream_t;
@@ -260,11 +260,6 @@ typedef struct st_quicly_transport_parameters_t {
      */
     uint64_t active_connection_id_limit;
 } quicly_transport_parameters_t;
-
-struct st_quicly_cid_t {
-    uint8_t cid[QUICLY_MAX_CID_LEN_V1];
-    uint8_t len;
-};
 
 /**
  * Guard value. We would never send path_id of this value.
@@ -780,10 +775,6 @@ uint64_t quicly_determine_packet_number(uint32_t truncated, size_t num_bits, uin
 /**
  *
  */
-static int quicly_cid_is_equal(const quicly_cid_t *cid, ptls_iovec_t vec);
-/**
- *
- */
 static quicly_context_t *quicly_get_context(quicly_conn_t *conn);
 /**
  *
@@ -1078,11 +1069,6 @@ inline uint32_t quicly_num_streams(quicly_conn_t *conn)
 {
     struct _st_quicly_conn_public_t *c = (struct _st_quicly_conn_public_t *)conn;
     return c->host.bidi.num_streams + c->host.uni.num_streams + c->peer.bidi.num_streams + c->peer.uni.num_streams;
-}
-
-inline int quicly_cid_is_equal(const quicly_cid_t *cid, ptls_iovec_t vec)
-{
-    return cid->len == vec.len && memcmp(cid->cid, vec.base, vec.len) == 0;
 }
 
 inline quicly_context_t *quicly_get_context(quicly_conn_t *conn)

--- a/include/quicly/cid.h
+++ b/include/quicly/cid.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020 Fastly, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef cid_h
+#define cid_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include "picotls.h"
+#include "quicly/constants.h"
+
+typedef struct st_quicly_cid_t quicly_cid_t;
+
+struct st_quicly_cid_t {
+    uint8_t cid[QUICLY_MAX_CID_LEN_V1];
+    uint8_t len;
+};
+
+static void quicly_set_cid(quicly_cid_t *dest, ptls_iovec_t src);
+static int quicly_cid_is_equal(const quicly_cid_t *cid, ptls_iovec_t vec);
+
+inline int quicly_cid_is_equal(const quicly_cid_t *cid, ptls_iovec_t vec)
+{
+    return cid->len == vec.len && memcmp(cid->cid, vec.base, vec.len) == 0;
+}
+
+inline void quicly_set_cid(quicly_cid_t *dest, ptls_iovec_t src)
+{
+    memcpy(dest->cid, src.base, src.len);
+    dest->len = src.len;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/quicly/cid.h
+++ b/include/quicly/cid.h
@@ -32,14 +32,71 @@ extern "C" {
 #include "quicly/constants.h"
 
 typedef struct st_quicly_cid_t quicly_cid_t;
+typedef struct st_quicly_received_cid_t quicly_received_cid_t;
+typedef struct st_quicly_received_cid_set_t quicly_received_cid_set_t;
 
 struct st_quicly_cid_t {
     uint8_t cid[QUICLY_MAX_CID_LEN_V1];
     uint8_t len;
 };
 
+/**
+ * records a CID given by the peer
+ */
+struct st_quicly_received_cid_t {
+    /**
+     * indicates whether this record holds an active (given by peer and not retired) CID
+     */
+    int is_active;
+    /**
+     * sequence number of the CID
+     *
+     * If is_active, this represents the sequence number associated with the CID.
+     * If !is_active, this represents a "reserved" slot, meaning that we are expecting to receive a NEW_CONNECTION_ID frame
+     * with this sequence number. This helps determine if a received frame is carrying a CID that is already retired.
+     */
+    uint64_t sequence;
+    struct st_quicly_cid_t cid;
+    uint8_t stateless_reset_token[QUICLY_STATELESS_RESET_TOKEN_LEN];
+};
+
+/**
+ * structure to hold active connection IDs received from the peer
+ */
+struct st_quicly_received_cid_set_t {
+    /**
+     * we retain QUICLY_LOCAL_ACTIVE_CONNECTION_ID_LIMIT active connection IDs
+     * cids[0] holds the current (in use) CID which is used when emitting packets
+     */
+    struct st_quicly_received_cid_t cids[QUICLY_LOCAL_ACTIVE_CONNECTION_ID_LIMIT];
+    /**
+     * we expect to receive CIDs with sequence number smaller than or equal to this number
+     */
+    uint64_t _largest_sequence_expected;
+};
+
 static void quicly_set_cid(quicly_cid_t *dest, ptls_iovec_t src);
 static int quicly_cid_is_equal(const quicly_cid_t *cid, ptls_iovec_t vec);
+void quicly_received_cid_init(struct st_quicly_received_cid_set_t *set);
+/**
+ * registers received connection ID
+ * returns 0 if successfully (registered or ignored because of duplication/stale information), transport error code otherwise
+ */
+int quicly_received_cid_register(struct st_quicly_received_cid_set_t *set, uint64_t sequence, const uint8_t *cid, size_t cid_len,
+                                 const uint8_t srt[QUICLY_STATELESS_RESET_TOKEN_LEN]);
+/**
+ * unregisters specified CID from the store
+ * returns 0 if success, 1 if failure
+ */
+int quicly_received_cid_unregister(struct st_quicly_received_cid_set_t *set, uint64_t sequence);
+/**
+ * unregister all CIDs with sequence number smaller than seq_unreg_prior_to
+ *
+ * @param unregistered_seqs sequence numbers of unregistered CIDs are returned, packed from the begining of the array
+ * @return the number of unregistered CIDs
+ */
+size_t quicly_received_cid_unregister_prior_to(struct st_quicly_received_cid_set_t *set, uint64_t seq_unreg_prior_to,
+                                               uint64_t unregistered_seqs[QUICLY_LOCAL_ACTIVE_CONNECTION_ID_LIMIT]);
 
 inline int quicly_cid_is_equal(const quicly_cid_t *cid, ptls_iovec_t vec)
 {

--- a/lib/cid.c
+++ b/lib/cid.c
@@ -22,3 +22,140 @@
 
 #include <string.h>
 #include "quicly/cid.h"
+
+void quicly_received_cid_init(struct st_quicly_received_cid_set_t *set)
+{
+    memset(set, 0, sizeof(*set));
+    for (size_t i = 0; i < PTLS_ELEMENTSOF(set->cids); i++) {
+        set->cids[i].sequence = i;
+    }
+    set->_largest_sequence_expected = PTLS_ELEMENTSOF(set->cids) - 1;
+}
+
+/**
+ * promote CID at idx_to_promote as the current CID for communication
+ * i.e. swap cids[idx_to_promote] and cids[0]
+ */
+static void promote_cid(struct st_quicly_received_cid_set_t *set, size_t idx_to_promote)
+{
+    uint64_t seq_tmp = set->cids[0].sequence;
+
+    assert(idx_to_promote > 0);
+    assert(!set->cids[0].is_active);
+
+    set->cids[0] = set->cids[idx_to_promote];
+    set->cids[idx_to_promote].is_active = 0;
+    set->cids[idx_to_promote].sequence = seq_tmp;
+}
+
+int quicly_received_cid_register(struct st_quicly_received_cid_set_t *set, uint64_t sequence, const uint8_t *cid, size_t cid_len,
+                                 const uint8_t srt[QUICLY_STATELESS_RESET_TOKEN_LEN])
+{
+    int was_stored = 0;
+
+    if (set->_largest_sequence_expected < sequence)
+        return QUICLY_TRANSPORT_ERROR_CONNECTION_ID_LIMIT;
+
+    for (size_t i = 0; i < PTLS_ELEMENTSOF(set->cids); i++) {
+        if (set->cids[i].is_active) {
+            /* compare newly received CID against what we already have, to see if there is duplication/conflicts */
+
+            /* If an endpoint receives a NEW_CONNECTION_ID frame that repeats a previously issued connection ID with
+             * a different Stateless Reset Token or a different sequence number, or if a sequence number is used for
+             * different connection IDs, the endpoint MAY treat that receipt as a connection error of type PROTOCOL_VIOLATION.
+             * (19.15)
+             */
+            if (quicly_cid_is_equal(&set->cids[i].cid, ptls_iovec_init(cid, cid_len))) {
+                if (set->cids[i].sequence == sequence &&
+                    memcmp(set->cids[i].stateless_reset_token, srt, QUICLY_STATELESS_RESET_TOKEN_LEN) == 0) {
+                    /* likely a duplicate due to retransmission */
+                    return 0;
+                } else {
+                    /* received a frame that carries conflicting information */
+                    return QUICLY_TRANSPORT_ERROR_PROTOCOL_VIOLATION;
+                }
+            }
+            /* here we know CID is not equal */
+            if (set->cids[i].sequence == sequence)
+                return QUICLY_TRANSPORT_ERROR_PROTOCOL_VIOLATION;
+        } else if (!was_stored && set->cids[i].sequence == sequence) {
+            set->cids[i].sequence = sequence;
+            quicly_set_cid(&set->cids[i].cid, ptls_iovec_init(cid, cid_len));
+            memcpy(set->cids[i].stateless_reset_token, srt, QUICLY_STATELESS_RESET_TOKEN_LEN);
+            set->cids[i].is_active = 1;
+            was_stored = 1;
+            if (i > 0 && !set->cids[0].is_active) {
+                /* promote this CID for communication */
+                promote_cid(set, i);
+            }
+        }
+    }
+
+    /* execution reaches here in two cases, 1) normal path, i.e. new CID was successfully registered, and 2) new CID was already
+     * retired (was_stored == 0). */
+    return 0;
+}
+
+static void do_unregister(struct st_quicly_received_cid_set_t *set, size_t idx_to_unreg)
+{
+    assert(set->cids[idx_to_unreg].is_active);
+
+    set->cids[idx_to_unreg].is_active = 0;
+    set->cids[idx_to_unreg].sequence = ++set->_largest_sequence_expected;
+}
+
+int quicly_received_cid_unregister(struct st_quicly_received_cid_set_t *set, uint64_t sequence)
+{
+    uint64_t min_seq = UINT64_MAX, min_seq_idx = UINT64_MAX;
+    for (size_t i = 0; i < PTLS_ELEMENTSOF(set->cids); i++) {
+        if (sequence == set->cids[i].sequence) {
+            do_unregister(set, i);
+            if (i != 0)
+                return 0; /* if not retiring idx=0 (current in-use CID), simply return */
+        }
+        if (set->cids[i].is_active && min_seq > set->cids[i].sequence) {
+            /* find a CID with minimum sequence number, while iterating over the array */
+            min_seq = set->cids[i].sequence;
+            min_seq_idx = i;
+        }
+    }
+
+    if (!set->cids[0].is_active) {
+        /* we have retired the current CID (idx=0) */
+        if (min_seq_idx != UINT64_MAX)
+            promote_cid(set, min_seq_idx);
+        return 0;
+    } else {
+        /* we did not unregister any slot */
+        return 1;
+    }
+}
+
+size_t quicly_received_cid_unregister_prior_to(struct st_quicly_received_cid_set_t *set, uint64_t seq_unreg_prior_to,
+                                               uint64_t unregistered_seqs[QUICLY_LOCAL_ACTIVE_CONNECTION_ID_LIMIT])
+{
+    uint64_t min_seq = UINT64_MAX, min_seq_idx = UINT64_MAX;
+    size_t num_unregistered = 0;
+    for (size_t i = 0; i < PTLS_ELEMENTSOF(set->cids); i++) {
+        if (set->cids[i].is_active) {
+            if (set->cids[i].sequence < seq_unreg_prior_to) {
+                unregistered_seqs[num_unregistered++] = set->cids[i].sequence;
+                do_unregister(set, i);
+                continue;
+            }
+            if (min_seq > set->cids[i].sequence) {
+                /* find a CID with minimum sequence number, while iterating over the array */
+                min_seq = set->cids[i].sequence;
+                min_seq_idx = i;
+            }
+        }
+    }
+
+    if (!set->cids[0].is_active) {
+        /* we have retired the current CID (idx=0) */
+        if (min_seq_idx != UINT64_MAX)
+            promote_cid(set, min_seq_idx);
+    }
+
+    return num_unregistered;
+}

--- a/lib/cid.c
+++ b/lib/cid.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020 Fastly, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <string.h>
+#include "quicly/cid.h"

--- a/t/cid.c
+++ b/t/cid.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2020 Fastly, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "test.h"
+#include "quicly/cid.h"
+
+#define CID_LEN 8
+
+/* clang-format off */
+static uint8_t cids[][CID_LEN] = {
+	{0, 1, 2, 3, 4, 5, 6, 7}, /* 0 */
+	{1, 2, 3, 4, 5, 6, 7, 0},
+	{2, 3, 4, 5, 6, 7, 0, 1},
+	{3, 4, 5, 6, 7, 0, 1, 2},
+	{4, 5, 6, 7, 0, 1, 2, 3},
+	{5, 6, 7, 0, 1, 2, 3, 4},
+	{6, 7, 0, 1, 2, 3, 4, 5},
+	{7, 0, 1, 2, 3, 4, 5, 6},
+	{8, 9, 10, 11, 12, 13, 14, 15}, /* 8 */
+};
+
+static uint8_t srts[][QUICLY_STATELESS_RESET_TOKEN_LEN] = {
+	{0},
+	{1},
+	{2},
+	{3},
+	{4},
+	{5},
+	{6},
+	{7},
+	{8},
+};
+/* clang-format on */
+
+void test_cid(void)
+{
+    quicly_received_cid_set_t set;
+
+    quicly_received_cid_init(&set);
+    /* fill CIDs */
+    for (int i = 0; i < 4; i++)
+        ok(quicly_received_cid_register(&set, i, cids[i], CID_LEN, srts[i]) == 0);
+    /* active CIDs = {*0, 1, 2, 3} (*0 is the current one) */
+
+    /* dup */
+    ok(quicly_received_cid_register(&set, 1, cids[1], CID_LEN, srts[1]) == 0);
+    /* same CID with different sequence number */
+    ok(quicly_received_cid_register(&set, 0, cids[1], CID_LEN, srts[1]) != 0);
+    /* already full */
+    ok(quicly_received_cid_register(&set, 4, cids[4], CID_LEN, srts[4]) == QUICLY_TRANSPORT_ERROR_CONNECTION_ID_LIMIT);
+
+    /* try to unregister something doesn't exist */
+    ok(quicly_received_cid_unregister(&set, 255) != 0);
+    /* retire seq=0 */
+    ok(quicly_received_cid_unregister(&set, 0) == 0);
+    /* active CIDs = {*1, 2, 3} */
+    ok(set.cids[0].is_active);
+    ok(set.cids[0].sequence == 1);
+    ok(memcmp(set.cids[0].cid.cid, cids[1], CID_LEN) == 0);
+    ok(memcmp(set.cids[0].stateless_reset_token, srts[1], QUICLY_STATELESS_RESET_TOKEN_LEN) == 0);
+    /* try to unregister sequence which is already unregistered */
+    ok(quicly_received_cid_unregister(&set, 0) != 0);
+    /* sequence number out of current acceptable window */
+    ok(quicly_received_cid_register(&set, 255, cids[4], CID_LEN, srts[4]) == QUICLY_TRANSPORT_ERROR_CONNECTION_ID_LIMIT);
+
+    /* ignore already retired CID */
+    ok(quicly_received_cid_register(&set, 0, cids[0], CID_LEN, srts[0]) == 0);
+
+    /* register 5th CID */
+    ok(quicly_received_cid_register(&set, 4, cids[4], CID_LEN, srts[4]) == 0);
+    /* active CIDs = {*1, 2, 3, 4} */
+
+    /* unregister seq=2 */
+    ok(quicly_received_cid_unregister(&set, 2) == 0);
+    /* active CIDs = {*1, 3, 4} */
+    ok(set.cids[0].is_active);
+    ok(set.cids[0].sequence == 1);
+
+    /* unregister prior to 5 -- seq=1,3,4 should be unregistered at this moment */
+    size_t num_unregistered;
+    uint64_t unregistered_seqs[QUICLY_LOCAL_ACTIVE_CONNECTION_ID_LIMIT];
+    num_unregistered = quicly_received_cid_unregister_prior_to(&set, 5, unregistered_seqs);
+    /* active CIDs = {} */
+    ok(num_unregistered == 3);
+    {
+        /* order in unregistered_seqs is not defined, so use a set to determine equivalence */
+        char expected[5] = {0, 1, 0, 1, 1}; /* expect seq=1,3,4 */
+        char seqset[5] = {0};
+        for (size_t i = 0; i < num_unregistered; i++) {
+            if (unregistered_seqs[i] < sizeof(seqset))
+                seqset[unregistered_seqs[i]] = 1;
+        }
+        ok(memcmp(seqset, expected, sizeof(seqset)) == 0);
+    }
+    ok(set.cids[0].is_active == 0);
+
+    /* install new CID after retiring everything */
+    ok(quicly_received_cid_register(&set, 5, cids[5], CID_LEN, srts[5]) == 0);
+    /* active CIDs = {*5} */
+    ok(set.cids[0].is_active);
+    ok(set.cids[0].sequence == 5);
+    ok(memcmp(set.cids[0].cid.cid, cids[5], CID_LEN) == 0);
+    ok(memcmp(set.cids[0].stateless_reset_token, srts[5], QUICLY_STATELESS_RESET_TOKEN_LEN) == 0);
+
+    /* install CID with out-of-order sequence */
+    ok(quicly_received_cid_register(&set, 8, cids[8], CID_LEN, srts[8]) == 0);
+    /* active CIDs = {*5, 8} */
+    ok(quicly_received_cid_register(&set, 7, cids[7], CID_LEN, srts[7]) == 0);
+    /* active CIDs = {*5, 7, 8} */
+    ok(set.cids[0].is_active);
+    ok(set.cids[0].sequence == 5);
+
+    /* unregister prior to 8 -- seq=5,7 should be unregistered at this moment */
+    num_unregistered = quicly_received_cid_unregister_prior_to(&set, 8, unregistered_seqs);
+    /* active CIDs = {*8} */
+    ok(num_unregistered == 2);
+    {
+        /* order in unregistered_seqs is not defined, so use a set to determine equivalence */
+        char expected[8] = {0, 0, 0, 0, 0, 1, 0, 1}; /* expect seq=5,7 */
+        char seqset[8] = {0};
+        for (size_t i = 0; i < num_unregistered; i++) {
+            if (unregistered_seqs[i] < sizeof(seqset))
+                seqset[unregistered_seqs[i]] = 1;
+        }
+        ok(memcmp(seqset, expected, sizeof(seqset)) == 0);
+    }
+    ok(set.cids[0].is_active);
+    ok(set.cids[0].sequence == 8);
+}

--- a/t/test.c
+++ b/t/test.c
@@ -385,7 +385,7 @@ static void test_address_token_codec(void)
     input.remote.sin.sin_family = AF_INET;
     input.remote.sin.sin_addr.s_addr = htonl(0x7f000001);
     input.remote.sin.sin_port = htons(443);
-    set_cid(&input.retry.odcid, ptls_iovec_init("abcdefgh", 8));
+    quicly_set_cid(&input.retry.odcid, ptls_iovec_init("abcdefgh", 8));
     input.retry.cidpair_hash = 12345;
     strcpy((char *)input.appdata.bytes, "hello world");
     input.appdata.len = strlen((char *)input.appdata.bytes);

--- a/t/test.c
+++ b/t/test.c
@@ -492,6 +492,7 @@ int main(int argc, char **argv)
     subtest("simple", test_simple);
     subtest("stream-concurrency", test_stream_concurrency);
     subtest("loss", test_loss);
+    subtest("cid", test_cid);
 
     return done_testing();
 }

--- a/t/test.h
+++ b/t/test.h
@@ -56,5 +56,6 @@ void test_sentmap(void);
 void test_simple(void);
 void test_loss(void);
 void test_stream_concurrency(void);
+void test_cid(void);
 
 #endif


### PR DESCRIPTION
This PR refactors h2o/quicly#306, based on @kazuho 's [idea](https://github.com/h2o/quicly/pull/306#discussion_r411756206) that frame processing and state processing should be separated.

Now that state processing is contained in `cid.c`, this PR also adds a unit test for CID handling (state processing) logic.
